### PR TITLE
Fix pread not setting size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gfapi-sys"
 description = "This crates provides FFI bindings for Gluster's API"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Chris Holcombe <chris.holcombe@canonical.com>"]
 repository = "https://github.com/gluster/Gfapi-sys"
 documentation = "https://docs.rs/gfapi-sys"

--- a/src/gluster.rs
+++ b/src/gluster.rs
@@ -353,7 +353,7 @@ impl Gluster {
 
     pub fn pread(&self,
                  file_handle: *mut Struct_glfs_fd,
-                 fill_buffer: &mut [u8],
+                 fill_buffer: &mut Vec<u8>,
                  count: usize,
                  offset: i64,
                  flags: i32)
@@ -367,6 +367,7 @@ impl Gluster {
             if read_size < 0 {
                 return Err(GlusterError::new(get_error()));
             }
+            fill_buffer.set_len(read_size as usize);
             Ok(read_size)
         }
     }


### PR DESCRIPTION
pread wasn't actually setting the size of the buffer it was reading into resulting in Rust not seeing any data in the buffer.  