### PR TITLE
Update uuid to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 errno = "^0.2"
 libc = "^0.2"
 log = "~0.3"
-uuid = {version="~0.4", features=["use_std"]}
+uuid = {version="0.6", features=["std"]}
 
 [badges]
 travis-ci = { repository = "gluster/Gfapi-sys" }


### PR DESCRIPTION
Hey

Updating this crate to 0.6 since the new release is out. There are no further changes required. 

`use_std` is deprecated and renamed to `std` to comply with the Rust conventions. 